### PR TITLE
Add puma to benchmarking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in pico_http_parser.gemspec
 gemspec
 gem "rake-compiler"
+
+
+group :development, :test do
+  gem "unicorn"
+  gem "puma"
+  gem "benchmark-ips"
+end

--- a/benchmark/benchmark.rb
+++ b/benchmark/benchmark.rb
@@ -8,32 +8,44 @@ request_bodys = [
   "GET /foo/bar/baz.html?key=value HTTP/1.0\r\nHost: blooperblorp\r\nCookie: foobar\r\nX-Forwarded-For: 127.0.0.1\r\nUser-Agent: Mozilla/5.0\r\n\r\n",
   "GET /foo/bar/baz.html?key=value HTTP/1.0\r\nHost: blooperblorp\r\nCookie: foobar\r\nX-Forwarded-For: 127.0.0.1\r\nUser-Agent: Mozilla/5.0\r\nAccept: X-5\r\nConnection: XXXXXX-6\r\nReferer: XXXXXXXX-7\r\nAccept-Encoding: XXXXXXX8\r\nCache-Control: XXXXXXXX9\r\nIf-Modified-Since: XXXXXXXXXXXXXXX10\r\n\r\n",
   "GET /foo/bar/baz.html?key=value HTTP/1.0\r\n\r\n"
-];
+]
+
 
 request_bodys.each do |request_body|
-puts("benchmark #{request_body}");
-Benchmark.ips do |x|
-  x.time = 5
-  x.warmup = 1
+  puts("benchmark #{request_body}")
 
-  x.report("PicoHTTPParser") {
-    env = {}
-    PicoHTTPParser.parse_http_request(request_body,env)
-  }
+  Benchmark.ips do |x|
+    x.time = 5
+    x.warmup = 1
 
-  begin
-    require 'unicorn'
-    include Unicorn
-    x.report("Unicorn's HttpParser") {
-      parser = HttpParser.new
-      parser.buf << request_body
-      env = parser.parse
+    x.report("PicoHTTPParser") {
+      env = {}
+      PicoHTTPParser.parse_http_request(request_body,env)
     }
-  rescue LoadError
-    puts("Can't benchmark unicorn as it couldn't be loaded.")
-  end
 
-  x.compare!
-end
+    begin
+      require 'unicorn'
+      x.report("Unicorn's HttpParser") {
+        parser = Unicorn::HttpParser.new
+        parser.buf << request_body
+        env = parser.parse
+      }
+    rescue LoadError
+      puts("Can't benchmark unicorn as it couldn't be loaded.")
+    end
+
+    begin
+      require 'puma/puma_http11'
+      x.report("Puma's HttpParser") {
+        parser = Puma::HttpParser.new
+        env = {}
+        nread = parser.execute(env, request_body, 0)
+      }
+    rescue LoadError
+      puts("Can't benchmark puma as it couldn't be loaded.")
+    end
+
+    x.compare!
+  end
 end
 


### PR DESCRIPTION
Hi!

Really cool repo! I was interested in PicoHTTPParser and maybe utilizing it in Ruby HTTP servers.

I added `puma` to the benchmarks game,
here are the results:
```
benchmark GET /foo/bar/baz.html?key=value HTTP/1.0
Host: blooperblorp

Warming up --------------------------------------
      PicoHTTPParser    34.238k i/100ms
Unicorn's HttpParser    21.497k i/100ms
   Puma's HttpParser    28.731k i/100ms
Calculating -------------------------------------
      PicoHTTPParser    407.742k (± 7.5%) i/s -      2.054M in   5.072453s
Unicorn's HttpParser    245.186k (± 5.1%) i/s -      1.225M in   5.012252s
   Puma's HttpParser    319.115k (± 6.5%) i/s -      1.609M in   5.062610s

Comparison:
      PicoHTTPParser:   407741.8 i/s
   Puma's HttpParser:   319115.1 i/s - 1.28x  slower
Unicorn's HttpParser:   245185.5 i/s - 1.66x  slower

benchmark GET /foo/bar/baz.html?key=value HTTP/1.0
Host: blooperblorp
User-Agent: Mozilla/5.0

Warming up --------------------------------------
      PicoHTTPParser    31.368k i/100ms
Unicorn's HttpParser    20.564k i/100ms
   Puma's HttpParser    25.343k i/100ms
Calculating -------------------------------------
      PicoHTTPParser    303.735k (± 4.7%) i/s -      1.537M in   5.071649s
Unicorn's HttpParser    227.471k (± 5.5%) i/s -      1.152M in   5.077659s
   Puma's HttpParser    288.050k (± 5.3%) i/s -      1.445M in   5.029210s

Comparison:
      PicoHTTPParser:   303735.3 i/s
   Puma's HttpParser:   288050.0 i/s - same-ish: difference falls within error
Unicorn's HttpParser:   227471.0 i/s - 1.34x  slower

benchmark GET /foo/bar/baz.html?key=value HTTP/1.0
Host: blooperblorp
Cookie: foobar
X-Forwarded-For: 127.0.0.1
User-Agent: Mozilla/5.0

Warming up --------------------------------------
      PicoHTTPParser    25.651k i/100ms
Unicorn's HttpParser    18.418k i/100ms
   Puma's HttpParser    20.027k i/100ms
Calculating -------------------------------------
      PicoHTTPParser    214.656k (± 5.2%) i/s -      1.077M in   5.032581s
Unicorn's HttpParser    199.166k (± 5.0%) i/s -    994.572k in   5.005539s
   Puma's HttpParser    219.953k (± 4.7%) i/s -      1.101M in   5.019175s

Comparison:
   Puma's HttpParser:   219953.0 i/s
      PicoHTTPParser:   214655.8 i/s - same-ish: difference falls within error
Unicorn's HttpParser:   199166.4 i/s - 1.10x  slower

benchmark GET /foo/bar/baz.html?key=value HTTP/1.0
Host: blooperblorp
Cookie: foobar
X-Forwarded-For: 127.0.0.1
User-Agent: Mozilla/5.0
Accept: X-5
Connection: XXXXXX-6
Referer: XXXXXXXX-7
Accept-Encoding: XXXXXXX8
Cache-Control: XXXXXXXX9
If-Modified-Since: XXXXXXXXXXXXXXX10

Warming up --------------------------------------
      PicoHTTPParser    19.007k i/100ms
Unicorn's HttpParser    12.281k i/100ms
   Puma's HttpParser    14.035k i/100ms
Calculating -------------------------------------
      PicoHTTPParser    122.288k (± 7.6%) i/s -    608.224k in   5.006490s
Unicorn's HttpParser    127.999k (± 5.4%) i/s -    650.893k in   5.099537s
   Puma's HttpParser    146.319k (± 4.9%) i/s -    743.855k in   5.095644s

Comparison:
   Puma's HttpParser:   146319.3 i/s
Unicorn's HttpParser:   127999.0 i/s - 1.14x  slower
      PicoHTTPParser:   122287.8 i/s - 1.20x  slower

benchmark GET /foo/bar/baz.html?key=value HTTP/1.0

Warming up --------------------------------------
      PicoHTTPParser    37.531k i/100ms
Unicorn's HttpParser    23.285k i/100ms
   Puma's HttpParser    30.545k i/100ms
Calculating -------------------------------------
      PicoHTTPParser    414.294k (± 8.3%) i/s -      2.064M in   5.022161s
Unicorn's HttpParser    255.969k (± 4.3%) i/s -      1.281M in   5.012732s
   Puma's HttpParser    356.938k (± 5.9%) i/s -      1.802M in   5.067360s

Comparison:
      PicoHTTPParser:   414293.9 i/s
   Puma's HttpParser:   356937.6 i/s - 1.16x  slower
Unicorn's HttpParser:   255969.3 i/s - 1.62x  slower
```

And looks like Puma's HttpParser is fighthing here :)